### PR TITLE
Update regex

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ The default patterns only target anchor tags which use the http protocol, you ca
 // default patterns
 huntsman.extension( 'recurse', {
   pattern: {
-    search: /a([^>]+)href\s?=\s?['"]([^"'#]+)/gi,
+    search: /<a([^>]+)href\s?=\s?['"]([^"'#]+)/gi,
     refine: /['"]([^"'#]+)$/,
     filter: /^https?:\/\//
   }


### PR DESCRIPTION
Without the change the regex also matches other tags with a `href` that have any a before it. E.g. `<link rel="apple-touch-icon-precomposed" href="/media/favicon-iphone.png" />` would match `apple-touch-icon-precomposed" href="/media/favicon-iphone.png"`